### PR TITLE
Add support for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "illuminate/support": "~5.0"
+        "illuminate/support": "~5.8|^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I didn't see any deprecated string or array helpers, so I think this will be enough.